### PR TITLE
Use `std::time::Duration` for expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ vmemcached = "0.1.0"
 
 ```rust
 let pool = vmemcached::Pool::builder()
-  .connection_timeout(std::time::Duration::from_secs(1))
-  .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
-  .expect("Memcache is available at localhost port 11211");
+    .connection_timeout(std::time::Duration::from_secs(1))
+    .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
+    .expect("Memcache is available at localhost port 11211");
 
 let client = vmemcached::Client::with_pool(pool);
 client.set("sample", "bar", 10).unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,7 @@ use r2d2::PooledConnection;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::time::Duration;
 
 use crate::connection::ConnectionManager;
 use crate::error::{ClientError, MemcacheError};
@@ -45,10 +46,12 @@ impl Client {
     ///
     /// ```rust
     /// let pool = vmemcached::Pool::builder()
-    /// .connection_timeout(std::time::Duration::from_secs(1))
-    /// .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
-    /// .unwrap();
+    ///     .connection_timeout(std::time::Duration::from_secs(1))
+    ///     .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
+    ///     .unwrap();
+    ///
     /// let client = vmemcached::Client::with_pool(pool);
+    ///
     /// client.version().unwrap();
     /// ```
     pub fn version(&self) -> Result<String, MemcacheError> {
@@ -61,10 +64,12 @@ impl Client {
     ///
     /// ```rust
     /// let pool = vmemcached::Pool::builder()
-    /// .connection_timeout(std::time::Duration::from_secs(1))
-    /// .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
-    /// .unwrap();
+    ///     .connection_timeout(std::time::Duration::from_secs(1))
+    ///     .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
+    ///     .unwrap();
+    ///
     /// let client = vmemcached::Client::with_pool(pool);
+    ///
     /// client.flush().unwrap();
     /// ```
     #[cfg(not(feature = "mcrouter"))]
@@ -78,10 +83,12 @@ impl Client {
     ///
     /// ```rust
     /// let pool = vmemcached::Pool::builder()
-    /// .connection_timeout(std::time::Duration::from_secs(1))
-    /// .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
-    /// .unwrap();
+    ///     .connection_timeout(std::time::Duration::from_secs(1))
+    ///     .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
+    ///     .unwrap();
+    ///
     /// let client = vmemcached::Client::with_pool(pool);
+    ///
     /// client.flush_with_delay(10).unwrap();
     /// ```
     #[cfg(not(feature = "mcrouter"))]
@@ -95,10 +102,12 @@ impl Client {
     ///
     /// ```rust
     /// let pool = vmemcached::Pool::builder()
-    /// .connection_timeout(std::time::Duration::from_secs(1))
-    /// .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
-    /// .unwrap();
+    ///     .connection_timeout(std::time::Duration::from_secs(1))
+    ///     .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
+    ///     .unwrap();
+    ///
     /// let client = vmemcached::Client::with_pool(pool);
+    ///
     /// let _: Option<String> = client.get("foo").unwrap();
     /// ```
     pub fn get<K: AsRef<[u8]>, T: DeserializeOwned>(&self, key: K) -> Result<Option<T>, MemcacheError> {
@@ -112,14 +121,21 @@ impl Client {
     ///
     /// ```rust
     /// let pool = vmemcached::Pool::builder()
-    /// .connection_timeout(std::time::Duration::from_secs(1))
-    /// .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
-    /// .unwrap();
+    ///     .connection_timeout(std::time::Duration::from_secs(1))
+    ///     .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
+    ///     .unwrap();
+    ///
     /// let client = vmemcached::Client::with_pool(pool);
-    /// client.set("foo", "bar", 10).unwrap();
+    ///
+    /// client.set("foo", "bar", std::time::Duration::from_secs(10)).unwrap();
     /// # client.flush().unwrap();
     /// ```
-    pub fn set<K: AsRef<[u8]>, T: Serialize>(&self, key: K, value: T, expiration: u32) -> Result<(), MemcacheError> {
+    pub fn set<K: AsRef<[u8]>, T: Serialize>(
+        &self,
+        key: K,
+        value: T,
+        expiration: Duration,
+    ) -> Result<(), MemcacheError> {
         check_key_len(&key)?;
         self.get_connection()?.set(key, value, expiration)
     }
@@ -130,16 +146,23 @@ impl Client {
     ///
     /// ```rust
     /// let pool = vmemcached::Pool::builder()
-    /// .connection_timeout(std::time::Duration::from_secs(1))
-    /// .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
-    /// .unwrap();
+    ///     .connection_timeout(std::time::Duration::from_secs(1))
+    ///     .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
+    ///     .unwrap();
+    ///
     /// let client = vmemcached::Client::with_pool(pool);
     /// let key = "add_test";
+    ///
     /// client.delete(key).unwrap();
-    /// client.add(key, "bar", 100000000).unwrap();
+    /// client.add(key, "bar", std::time::Duration::from_secs(100000000)).unwrap();
     /// # client.flush().unwrap();
     /// ```
-    pub fn add<K: AsRef<[u8]>, T: Serialize>(&self, key: K, value: T, expiration: u32) -> Result<(), MemcacheError> {
+    pub fn add<K: AsRef<[u8]>, T: Serialize>(
+        &self,
+        key: K,
+        value: T,
+        expiration: Duration,
+    ) -> Result<(), MemcacheError> {
         check_key_len(&key)?;
         self.get_connection()?.add(key, value, expiration)
     }
@@ -150,20 +173,22 @@ impl Client {
     ///
     /// ```rust
     /// let pool = vmemcached::Pool::builder()
-    /// .connection_timeout(std::time::Duration::from_secs(1))
-    /// .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
-    /// .unwrap();
+    ///     .connection_timeout(std::time::Duration::from_secs(1))
+    ///     .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
+    ///     .unwrap();
+    ///
     /// let client = vmemcached::Client::with_pool(pool);
     /// let key = "replace_test";
-    /// client.set(key, "bar", 0).unwrap();
-    /// client.replace(key, "baz", 100000000).unwrap();
+    ///
+    /// client.set(key, "bar", std::time::Duration::from_secs(0)).unwrap();
+    /// client.replace(key, "baz", std::time::Duration::from_secs(100000000)).unwrap();
     /// # client.flush().unwrap();
     /// ```
     pub fn replace<K: AsRef<[u8]>, T: Serialize>(
         &self,
         key: K,
         value: T,
-        expiration: u32,
+        expiration: Duration,
     ) -> Result<(), MemcacheError> {
         check_key_len(&key)?;
         self.get_connection()?.replace(key, value, expiration)
@@ -175,10 +200,12 @@ impl Client {
     ///
     /// ```rust
     /// let pool = vmemcached::Pool::builder()
-    /// .connection_timeout(std::time::Duration::from_secs(1))
-    /// .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
-    /// .unwrap();
+    ///     .connection_timeout(std::time::Duration::from_secs(1))
+    ///     .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
+    ///     .unwrap();
+    ///
     /// let client = vmemcached::Client::with_pool(pool);
+    ///
     /// client.delete("foo").unwrap();
     /// # client.flush().unwrap();
     /// ```
@@ -193,16 +220,18 @@ impl Client {
     ///
     /// ```rust
     /// let pool = vmemcached::Pool::builder()
-    /// .connection_timeout(std::time::Duration::from_secs(1))
-    /// .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
-    /// .unwrap();
+    ///     .connection_timeout(std::time::Duration::from_secs(1))
+    ///     .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
+    ///     .unwrap();
+    ///
     /// let client = vmemcached::Client::with_pool(pool);
-    /// assert_eq!(client.touch("not_exists_key", 11211).unwrap(), false);
-    /// client.set("foo", "bar", 123).unwrap();
-    /// assert_eq!(client.touch("foo", 11211).unwrap(), true);
+    /// assert_eq!(client.touch("not_exists_key", std::time::Duration::from_secs(11211)).unwrap(), false);
+    ///
+    /// client.set("foo", "bar", std::time::Duration::from_secs(123)).unwrap();
+    /// assert_eq!(client.touch("foo", std::time::Duration::from_secs(11211)).unwrap(), true);
     /// # client.flush().unwrap();
     /// ```
-    pub fn touch<K: AsRef<[u8]>>(&self, key: K, expiration: u32) -> Result<bool, MemcacheError> {
+    pub fn touch<K: AsRef<[u8]>>(&self, key: K, expiration: Duration) -> Result<bool, MemcacheError> {
         check_key_len(&key)?;
         self.get_connection()?.touch(key, expiration)
     }
@@ -212,9 +241,10 @@ impl Client {
     /// Example:
     /// ```rust
     /// let pool = vmemcached::Pool::builder()
-    /// .connection_timeout(std::time::Duration::from_secs(1))
-    /// .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
-    /// .unwrap();
+    ///     .connection_timeout(std::time::Duration::from_secs(1))
+    ///     .build(vmemcached::ConnectionManager::new("memcache://localhost:11211").unwrap())
+    ///     .unwrap();
+    ///
     /// let client = vmemcached::Client::with_pool(pool);
     /// let stats = client.stats().unwrap();
     /// ```
@@ -240,7 +270,7 @@ mod tests {
     #[test]
     fn delete() {
         let client = connect("memcache://localhost:11211").unwrap();
-        client.set("an_exists_key", "value", 0).unwrap();
+        client.set("an_exists_key", "value", Duration::from_secs(0)).unwrap();
         assert_eq!(client.delete("an_exists_key").unwrap(), true);
         assert_eq!(client.delete("a_not_exists_key").unwrap(), false);
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,9 +17,10 @@ pub struct Client(Pool<ConnectionManager>);
 
 pub(crate) fn check_key_len<K: AsRef<[u8]>>(key: K) -> Result<(), MemcacheError> {
     if key.as_ref().len() > 250 {
-        Err(ClientError::KeyTooLong)?
+        Err(ClientError::KeyTooLong.into())
+    } else {
+        Ok(())
     }
-    Ok(())
 }
 
 impl Client {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -146,7 +146,7 @@ impl TcpOptions {
 
 impl Transport {
     fn from_url(url: &Url) -> Result<Self, MemcacheError> {
-        let mut parts = url.scheme().splitn(2, "+");
+        let mut parts = url.scheme().splitn(2, '+');
         match parts.next() {
             Some(part) if part == "memcache" => (),
             _ => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use r2d2;
 use std::borrow::Cow;
 use std::error;
 use std::fmt;
@@ -69,15 +68,15 @@ pub enum CommandError {
 impl MemcacheError {
     pub(crate) fn try_from(s: &str) -> Result<&str, MemcacheError> {
         if s == "ERROR\r\n" {
-            Err(CommandError::InvalidCommand)?
+            Err(CommandError::InvalidCommand.into())
         } else if s.starts_with("CLIENT_ERROR") {
-            Err(ClientError::from(String::from(s)))?
+            Err(ClientError::from(String::from(s)).into())
         } else if s.starts_with("SERVER_ERROR") {
-            Err(ServerError::from(String::from(s)))?
+            Err(ServerError::from(String::from(s)).into())
         } else if s == "NOT_FOUND\r\n" {
-            Err(CommandError::KeyNotFound)?
+            Err(CommandError::KeyNotFound.into())
         } else if s == "EXISTS\r\n" {
-            Err(CommandError::KeyExists)?
+            Err(CommandError::KeyExists.into())
         } else {
             Ok(s)
         }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,5 +1,6 @@
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::time::Duration;
 
 mod ascii;
 
@@ -15,11 +16,25 @@ pub(crate) trait ProtocolTrait {
     #[cfg(not(feature = "mcrouter"))]
     fn flush_with_delay(&mut self, delay: u32) -> Result<(), MemcacheError>;
     fn get<K: AsRef<[u8]>, T: DeserializeOwned>(&mut self, key: K) -> Result<Option<T>, MemcacheError>;
-    fn set<K: AsRef<[u8]>, T: Serialize>(&mut self, key: K, value: T, expiration: u32) -> Result<(), MemcacheError>;
-    fn add<K: AsRef<[u8]>, T: Serialize>(&mut self, key: K, value: T, expiration: u32) -> Result<(), MemcacheError>;
-    fn replace<K: AsRef<[u8]>, T: Serialize>(&mut self, key: K, value: T, expiration: u32)
-        -> Result<(), MemcacheError>;
+    fn set<K: AsRef<[u8]>, T: Serialize>(
+        &mut self,
+        key: K,
+        value: T,
+        expiration: Duration,
+    ) -> Result<(), MemcacheError>;
+    fn add<K: AsRef<[u8]>, T: Serialize>(
+        &mut self,
+        key: K,
+        value: T,
+        expiration: Duration,
+    ) -> Result<(), MemcacheError>;
+    fn replace<K: AsRef<[u8]>, T: Serialize>(
+        &mut self,
+        key: K,
+        value: T,
+        expiration: Duration,
+    ) -> Result<(), MemcacheError>;
     fn delete<K: AsRef<[u8]>>(&mut self, key: K) -> Result<bool, MemcacheError>;
-    fn touch<K: AsRef<[u8]>>(&mut self, key: K, expiration: u32) -> Result<bool, MemcacheError>;
+    fn touch<K: AsRef<[u8]>>(&mut self, key: K, expiration: Duration) -> Result<bool, MemcacheError>;
     fn stats(&mut self) -> Result<Stats, MemcacheError>;
 }

--- a/tests/test_ascii.rs
+++ b/tests/test_ascii.rs
@@ -13,11 +13,11 @@ fn test_ascii() {
     thread::sleep(time::Duration::from_secs(1));
     client.flush().unwrap();
 
-    client.set("ascii_foo", "bar", 0).unwrap();
+    client.set("ascii_foo", "bar", time::Duration::from_secs(1)).unwrap();
     let value: Option<String> = client.get("ascii_foo").unwrap();
     assert_eq!(value, Some("bar".into()));
 
-    client.touch("ascii_foo", 1000).unwrap();
+    client.touch("ascii_foo", time::Duration::from_secs(1000)).unwrap();
 
     let value: Option<String> = client.get("not_exists_key").unwrap();
     assert_eq!(value, None);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,7 +15,7 @@ fn gen_random_key() -> String {
         .map(|()| thread_rng().sample(Alphanumeric))
         .take(10)
         .collect::<Vec<u8>>();
-    return String::from_utf8(bs).unwrap();
+    String::from_utf8(bs).unwrap()
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -21,15 +21,16 @@ fn gen_random_key() -> String {
 #[test]
 fn tcp_test() {
     let client = helpers::connect("memcache://localhost:11211").unwrap();
+    let expiration = time::Duration::from_secs(0);
 
     client.version().unwrap();
 
-    client.set("foo", "bar", 0).unwrap();
+    client.set("foo", "bar", expiration).unwrap();
     client.flush().unwrap();
     let value: Option<String> = client.get("foo").unwrap();
     assert_eq!(value, None);
 
-    client.set("foo", "bar", 0).unwrap();
+    client.set("foo", "bar", expiration).unwrap();
     client.flush_with_delay(3).unwrap();
     let value: Option<String> = client.get("foo").unwrap();
     assert_eq!(value, Some(String::from("bar")));
@@ -37,31 +38,31 @@ fn tcp_test() {
     let value: Option<String> = client.get("foo").unwrap();
     assert_eq!(value, None);
 
-    client.set("foo", "bar", 0).unwrap();
-    let value = client.add("foo", "baz", 0);
+    client.set("foo", "bar", expiration).unwrap();
+    let value = client.add("foo", "baz", expiration);
     assert!(value.is_ok());
 
     client.delete("foo").unwrap();
     let value: Option<String> = client.get("foo").unwrap();
     assert_eq!(value, None);
 
-    client.add("foo", "bar", 0).unwrap();
+    client.add("foo", "bar", expiration).unwrap();
     let value: Option<String> = client.get("foo").unwrap();
     assert_eq!(value, Some(String::from("bar")));
 
-    client.replace("foo", "baz", 0).unwrap();
+    client.replace("foo", "baz", expiration).unwrap();
     let value: Option<String> = client.get("foo").unwrap();
     assert_eq!(value, Some(String::from("baz")));
 
-    assert_eq!(client.touch("foooo", 123).unwrap(), false);
-    client.set("fooo", 0, 0).unwrap();
-    assert_eq!(client.touch("fooo", 12345).unwrap(), true);
+    assert_eq!(client.touch("foooo", time::Duration::from_secs(123)).unwrap(), false);
+    client.set("fooo", 0, expiration).unwrap();
+    assert_eq!(client.touch("fooo", time::Duration::from_secs(12345)).unwrap(), true);
 
     let mut keys: Vec<String> = Vec::new();
     for _ in 0..1000 {
         let key = gen_random_key();
         keys.push(key.clone());
-        client.set(key.as_str(), "xxx", 0).unwrap();
+        client.set(key.as_str(), "xxx", expiration).unwrap();
     }
 
     for key in keys {
@@ -79,22 +80,22 @@ fn tcp_test() {
             let client = helpers::connect("memcache://localhost:11211").unwrap();
             for j in 0..50 {
                 let value = format!("{}{}", value, j);
-                client.set(key.as_str(), &value, 0).unwrap();
+                client.set(key.as_str(), &value, expiration).unwrap();
                 let result: Option<String> = client.get(key.as_str()).unwrap();
                 assert_eq!(result.as_ref(), Some(&value));
 
-                let result = client.add(key.as_str(), &value, 0);
+                let result = client.add(key.as_str(), &value, expiration);
                 assert!(result.is_ok());
 
                 client.delete(key.as_str()).unwrap();
                 let result: Option<String> = client.get(key.as_str()).unwrap();
                 assert_eq!(result, None);
 
-                client.add(key.as_str(), &value, 0).unwrap();
+                client.add(key.as_str(), &value, expiration).unwrap();
                 let result: Option<String> = client.get(key.as_str()).unwrap();
                 assert_eq!(result.as_ref(), Some(&value));
 
-                client.replace(key.as_str(), &value, 0).unwrap();
+                client.replace(key.as_str(), &value, expiration).unwrap();
                 let result: Option<String> = client.get(key.as_str()).unwrap();
                 assert_eq!(result.as_ref(), Some(&value));
             }


### PR DESCRIPTION
Changes expiration type from `u32` to `std::time::Duration` for better intention revealing.

Also fixed linting, formatting issues.

cc @ernestas-vinted