### PR TITLE
tests: add concurrent pool tests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -269,9 +269,9 @@ mod tests {
 
     #[test]
     fn delete() {
-        let client = connect("memcache://localhost:11211").unwrap();
-        client.set("an_exists_key", "value", Duration::from_secs(0)).unwrap();
-        assert_eq!(client.delete("an_exists_key").unwrap(), true);
-        assert_eq!(client.delete("a_not_exists_key").unwrap(), false);
+        let mcrouter = connect("memcache://localhost:11311").unwrap();
+        mcrouter.set("an_exists_key", "value", Duration::from_secs(0)).unwrap();
+        assert_eq!(mcrouter.delete("an_exists_key").unwrap(), true);
+        assert_eq!(mcrouter.delete("a_not_exists_key").unwrap(), false);
     }
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -63,7 +63,7 @@ mod tests {
     }
 
     #[test]
-    fn test_simd_json_serde_annotations() {
+    fn test_simd_json() {
         let a = A {
             field: "a_struct".into(),
         };

--- a/src/protocol/ascii.rs
+++ b/src/protocol/ascii.rs
@@ -179,6 +179,7 @@ impl ProtocolTrait for AsciiProtocol<Stream> {
     ) -> Result<(), MemcacheError> {
         let options = Options {
             exptime: expiration,
+            noreply: true,
             ..Default::default()
         };
         self.store(StoreCommand::Set, key.as_ref(), value, &options).map(|_| ())

--- a/tests/test_ascii.rs
+++ b/tests/test_ascii.rs
@@ -1,30 +1,28 @@
-extern crate vmemcached;
-
 use std::{thread, time};
 
 mod helpers;
 
 #[test]
 fn test_ascii() {
-    // Testing mcrouter
-    let client = helpers::connect("memcache://localhost:11211?protocol=ascii").unwrap();
+    let mcrouter = helpers::connect("memcache://localhost:11311?protocol=ascii").unwrap();
+    let memcached = helpers::connect("memcache://localhost:11211?protocol=ascii").unwrap();
 
-    client.flush_with_delay(1).unwrap();
+    memcached.flush_with_delay(1).unwrap();
     thread::sleep(time::Duration::from_secs(1));
-    client.flush().unwrap();
+    memcached.flush().unwrap();
 
-    client.set("ascii_foo", "bar", time::Duration::from_secs(1)).unwrap();
-    let value: Option<String> = client.get("ascii_foo").unwrap();
+    mcrouter.set("ascii_foo", "bar", time::Duration::from_secs(1)).unwrap();
+    let value: Option<String> = mcrouter.get("ascii_foo").unwrap();
     assert_eq!(value, Some("bar".into()));
 
-    client.touch("ascii_foo", time::Duration::from_secs(1000)).unwrap();
+    mcrouter.touch("ascii_foo", time::Duration::from_secs(1000)).unwrap();
 
-    let value: Option<String> = client.get("not_exists_key").unwrap();
+    let value: Option<String> = mcrouter.get("not_exists_key").unwrap();
     assert_eq!(value, None);
 
-    client.delete("ascii_pend").unwrap();
-    let value: Option<String> = client.get("ascii_pend").unwrap();
+    mcrouter.delete("ascii_pend").unwrap();
+    let value: Option<String> = mcrouter.get("ascii_pend").unwrap();
     assert_eq!(value, None);
 
-    client.stats().unwrap();
+    mcrouter.stats().unwrap();
 }

--- a/tests/test_serde_objects.rs
+++ b/tests/test_serde_objects.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+use std::thread;
+use std::thread::JoinHandle;
+use std::time;
+
+mod helpers;
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+struct LargeObject {
+    field: String,
+    fields: Vec<String>,
+}
+
+#[test]
+fn test_serde_objects() {
+    let mcrouter = helpers::connect("memcache://localhost:11311?protocol=ascii").unwrap();
+
+    let key = "large_obj";
+
+    for i in 0..20 {
+        let object = LargeObject {
+            field: format!("{}", i + 29).repeat(2000),
+            fields: vec![format!("x{}>{}", i, i); 2002],
+        };
+
+        let got = mcrouter.set(key, object.clone(), time::Duration::from_secs(0));
+        assert!(got.is_ok());
+
+        let value: Option<LargeObject> = mcrouter.get(key).unwrap();
+        assert_eq!(value.as_ref(), Some(&object));
+    }
+}
+
+#[test]
+fn test_serde_objects_with_pool() {
+    let mcrouter = helpers::connect("memcache://localhost:11311?protocol=ascii").unwrap();
+
+    let key = "large_obj_threaded";
+
+    let total_threads = 40;
+
+    let mut handles: Vec<Option<JoinHandle<_>>> = Vec::new();
+    for x in 0..total_threads {
+        let mcrouter_clone = mcrouter.clone();
+
+        handles.push(Some(thread::spawn(move || {
+            for y in 0..total_threads * 3 {
+                let object = LargeObject {
+                    field: format!("{}", y + 29).repeat(y),
+                    fields: vec![format!("x: {} y: {}", x, y); x],
+                };
+
+                let got = mcrouter_clone.set(key, object.clone(), time::Duration::from_secs(5));
+                assert!(got.is_ok());
+
+                let value: Option<LargeObject> = mcrouter_clone.get(key).unwrap();
+                assert!(value.is_some());
+            }
+        })));
+    }
+
+    for i in 0..total_threads {
+        handles[i].take().unwrap().join().unwrap();
+    }
+}


### PR DESCRIPTION
mcrouter does not support flush/flush_with_delay commands, therefore had to split into two client better option would be to clean up after each set key using delete command.

Adding concurrent "same" pool tests 40 threads setting/getting objects 

