### PR TITLE
manager: handle io Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -136,3 +136,12 @@ impl From<String> for ClientError {
         ClientError::Error(Cow::Owned(s))
     }
 }
+
+impl From<bb8::RunError<MemcacheError>> for MemcacheError {
+    fn from(e: bb8::RunError<MemcacheError>) -> Self {
+        match e {
+            bb8::RunError::User(e) => e,
+            bb8::RunError::TimedOut => MemcacheError::Io(io::Error::from(io::ErrorKind::TimedOut)),
+        }
+    }
+}

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,10 +1,9 @@
 use async_trait::async_trait;
 use std::convert::TryFrom;
-use std::io;
 use url::Url;
 
 use crate::connection::Connection;
-use crate::driver;
+use crate::{driver, MemcacheError};
 
 /// A `bb8::ManageConnection` for `memcache_async::ascii::Protocol`.
 #[derive(Clone, Debug)]
@@ -30,21 +29,19 @@ impl TryFrom<&str> for ConnectionManager {
 #[async_trait]
 impl bb8::ManageConnection for ConnectionManager {
     type Connection = Connection;
-    type Error = io::Error;
+    type Error = MemcacheError;
 
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        Connection::connect(&*self.url.socket_addrs(|| None)?).await
+        Connection::connect(&*self.url.socket_addrs(|| None)?)
+            .await
+            .map_err(Into::into)
     }
 
     async fn is_valid(
         &self,
         conn: &mut bb8::PooledConnection<'_, Self>,
     ) -> Result<(), Self::Error> {
-        driver::version(conn)
-            .await
-            .map(|_| ())
-            // TODO: rethink this hides real error
-            .map_err(|_| io::Error::from(io::ErrorKind::Other))
+        driver::version(conn).await.map(|_| ())
     }
 
     fn has_broken(&self, _: &mut Self::Connection) -> bool {


### PR DESCRIPTION
Handle ConnectionManager `io::Error` by unwrapping `bb8::RunError` User & TimedOut variants. 