### PR TITLE
cargo: use pin-project-lite macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ nom = { version = "7", default-features = false, features = ["std"] }
 bytes = { version = "1", default-features = false, features =["std"] }
 bb8 = { version = "0.7", default-features = false }
 tokio = { version = "1.12", default-features = false, features = ["net", "io-util"] }
-pin-project = "1"
 async-trait = { version = "0.1", default-features = false }
 futures-util = "0.3"
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,14 +1,19 @@
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, BufReader, BufWriter, ReadBuf};
 use tokio::net::{TcpStream, ToSocketAddrs};
 
-/// Connection wrapper
-#[derive(Debug)]
-#[pin_project]
-pub struct Connection(#[pin] BufReader<BufWriter<TcpStream>>);
+pin_project! {
+    /// Connection wrapper
+    #[derive(Debug)]
+    #[must_use = "Connection do nothing unless polled"]
+    pub struct Connection {
+        #[pin]
+        stream: BufReader<BufWriter<TcpStream>>
+    }
+}
 
 impl AsyncRead for Connection {
     fn poll_read(
@@ -16,39 +21,39 @@ impl AsyncRead for Connection {
         cx: &mut Context,
         buf: &mut ReadBuf,
     ) -> Poll<io::Result<()>> {
-        self.project().0.poll_read(cx, buf)
+        self.project().stream.poll_read(cx, buf)
     }
 }
 
 impl AsyncWrite for Connection {
     fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
-        self.project().0.poll_write(cx, buf)
+        self.project().stream.poll_write(cx, buf)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
-        self.project().0.poll_flush(cx)
+        self.project().stream.poll_flush(cx)
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
-        self.project().0.poll_shutdown(cx)
+        self.project().stream.poll_shutdown(cx)
     }
 }
 
 impl AsyncBufRead for Connection {
     fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<&[u8]>> {
-        self.project().0.poll_fill_buf(cx)
+        self.project().stream.poll_fill_buf(cx)
     }
 
     fn consume(self: Pin<&mut Self>, amt: usize) {
-        self.project().0.consume(amt)
+        self.project().stream.consume(amt)
     }
 }
 
 impl Connection {
     /// Connect to to given socket address
     pub async fn connect<A: ToSocketAddrs>(address: A) -> Result<Connection, io::Error> {
-        TcpStream::connect(address)
-            .await
-            .map(|c| Connection(BufReader::new(BufWriter::new(c))))
+        TcpStream::connect(address).await.map(|c| Connection {
+            stream: BufReader::new(BufWriter::new(c)),
+        })
     }
 }


### PR DESCRIPTION
Derive macro attributes are not yet stable on rust stable track. This changes pin to pin-project-lite and derivation will be used via `pin_project` macro.