### PR TITLE
serde: remove simd json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ compress = ["brotli"]
 url = { version = "2", default-features = false }
 serde = { version = "1", default-features = false }
 brotli = { version = "3.3", default-features = false, features = ["std"], optional = true }
-simd-json = { version = "0.4", default-features = true, features = ["serde_impl", "allow-non-simd"] }
+serde_json = "1"
 btoi = { version = "0.4.2", default-features = false }
 nom = { version = "7", default-features = false, features = ["std"] }
 bytes = { version = "1", default-features = false, features =["std"] }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ vmemcached = "0.1.0"
 
  - ASCII protocol
  - Key interpreted as slice of u8 (bytes)
- - Value is accepted as implementing Serialize and is stored as JSON using simd-json crate
+ - Value is accepted as implementing Serialize and is stored as JSON using serde_json crate
  - Not supported: increment/decrement/append/prepend/gets operations due to JSON and compression
  - Feature: "compress" enable Brotli encoding/decoding
  - Tokio

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -6,7 +6,7 @@ mod compress {
     use std::io::{Cursor, Write};
 
     pub(crate) fn encode<T: Serialize>(value: T) -> Result<Vec<u8>, MemcacheError> {
-        let encoded = simd_json::to_vec(&value)?;
+        let encoded = serde_json::to_vec(&value)?;
 
         let mut writer = brotli::CompressorWriter::new(Vec::new(), 2048, 11, 22);
         let _ = writer.write_all(&encoded)?;
@@ -16,7 +16,7 @@ mod compress {
     pub(crate) fn decode<T: DeserializeOwned>(input: Vec<u8>) -> Result<T, MemcacheError> {
         let mut output = Vec::new();
         let _ = brotli::BrotliDecompress(&mut Cursor::new(input), &mut output)?;
-        Ok(simd_json::from_slice(&mut output)?)
+        Ok(serde_json::from_slice(&mut output)?)
     }
 }
 
@@ -27,11 +27,11 @@ mod plain {
     use serde::Serialize;
 
     pub(crate) fn encode<T: Serialize>(value: T) -> Result<Vec<u8>, MemcacheError> {
-        Ok(simd_json::to_vec(&value)?)
+        Ok(serde_json::to_vec(&value)?)
     }
 
-    pub(crate) fn decode<T: DeserializeOwned>(mut value: Vec<u8>) -> Result<T, MemcacheError> {
-        Ok(simd_json::from_slice(value.as_mut_slice())?)
+    pub(crate) fn decode<T: DeserializeOwned>(value: Vec<u8>) -> Result<T, MemcacheError> {
+        Ok(serde_json::from_slice(&value)?)
     }
 }
 
@@ -40,52 +40,3 @@ pub(crate) use compress::*;
 
 #[cfg(not(feature = "compress"))]
 pub(crate) use plain::*;
-
-#[cfg(test)]
-mod tests {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct A {
-        field: String,
-    }
-
-    #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct B {
-        field: String,
-    }
-
-    #[derive(Serialize, Deserialize, Debug, PartialEq, Default)]
-    struct C {
-        field: String,
-        #[serde(default)]
-        flag: bool,
-    }
-
-    #[test]
-    fn test_simd_json_serde_annotations() {
-        let a = A {
-            field: "a_struct".into(),
-        };
-
-        let b = B {
-            field: "B_struct".into(),
-        };
-
-        let mut a_encoded = simd_json::to_vec(&a).unwrap();
-        let mut b_encoded = simd_json::to_vec(&b).unwrap();
-
-        let b_decoded_from_a: Result<B, simd_json::Error> = simd_json::from_slice(&mut a_encoded);
-        assert!(b_decoded_from_a.is_ok());
-
-        let a_decoded_from_b: Result<A, simd_json::Error> = simd_json::from_slice(&mut b_encoded);
-        assert!(a_decoded_from_b.is_ok());
-
-        let c_decoded_from_b: Result<C, simd_json::Error> = simd_json::from_slice(&mut b_encoded);
-        assert!(
-            c_decoded_from_b.is_ok(),
-            "simd_json::Error: {:?}",
-            c_decoded_from_b
-        );
-    }
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,8 +33,8 @@ pub enum MemcacheError {
     Utf8Error(string::FromUtf8Error),
     /// ConnectionPool errors
     PoolError(bb8::RunError<io::Error>),
-    /// SIMD JSON error
-    Serde(simd_json::Error),
+    /// JSON error
+    Serde(serde_json::Error),
     /// Nom error
     Nom(String),
     /// Memcache error
@@ -111,8 +111,8 @@ impl From<bb8::RunError<io::Error>> for MemcacheError {
     }
 }
 
-impl From<simd_json::Error> for MemcacheError {
-    fn from(e: simd_json::Error) -> MemcacheError {
+impl From<serde_json::Error> for MemcacheError {
+    fn from(e: serde_json::Error) -> MemcacheError {
         MemcacheError::Serde(e)
     }
 }


### PR DESCRIPTION
SIMD json is compatible with complicated enum types, replacing it to vanilla serde_json. 