### PR TITLE
Enable default features for url crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 compress = ["brotli"]
 
 [dependencies]
-url = { version = "2", default-features = false }
+url = "2"
 serde = { version = "1", default-features = false }
 brotli = { version = "3.3", default-features = false, features = ["std"], optional = true }
 serde_json = { version = "1.0", default-features = true }


### PR DESCRIPTION
In order to make the rust-url compatible with no_std, the crate needs to introduce a `std` feature and make it default. See https://github.com/servo/rust-url/pull/831.

In order to reduce impact, downstream libraries should leave url's default features enabled (no other features are currently `default`).